### PR TITLE
feat: upload files and give public URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
+        "@types/mime-types": "^2.1.4",
         "@types/node": "^22.13.14",
         "@typescript-eslint/eslint-plugin": "^8.28.0",
         "@typescript-eslint/parser": "^8.28.0",
@@ -4058,6 +4059,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime-types": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
+    "@types/mime-types": "^2.1.4",
     "@types/node": "^22.13.14",
     "@typescript-eslint/eslint-plugin": "^8.28.0",
     "@typescript-eslint/parser": "^8.28.0",

--- a/src/tools/buckets.ts
+++ b/src/tools/buckets.ts
@@ -1,12 +1,10 @@
 import {
   CreateBucketCommand,
   DeleteBucketCommand,
-  ListBucketsCommand,
   paginateListBuckets,
 } from '@aws-sdk/client-s3';
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { createS3Client } from '../utils/create-s3-client.js';
-import { isBucketPublic } from '../utils/get-bucket-acls.js';
 import { ToolHandlers } from '../utils/types.js';
 
 const TIGRIS_LIST_BUCKETS_TOOL: Tool = {
@@ -109,14 +107,7 @@ const listBuckets = async () => {
       buckets.push(...page.Buckets);
     }
   }
-
-  return Promise.all(
-    buckets.map(async (bucket) => ({
-      name: bucket.Name,
-      createdAt: bucket.CreationDate,
-      isPublic: await isBucketPublic(S3, bucket.Name as string),
-    }))
-  );
+  return buckets;
 };
 
 const createBucket = async (bucketName: string, isPublic: boolean = false) => {

--- a/src/tools/objects.ts
+++ b/src/tools/objects.ts
@@ -8,7 +8,6 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { readFile } from 'node:fs/promises';
 import { createS3Client } from '../utils/create-s3-client.js';
-import { isBucketPublic } from '../utils/get-bucket-acls.js';
 import { ToolHandlers } from '../utils/types.js';
 
 const TIGRIS_LIST_OBJECTS_TOOL: Tool = {
@@ -280,7 +279,7 @@ export const OBJECT_TOOLS_HANDLER: ToolHandlers = {
     };
   },
   [TIGRIS_UPLOAD_FILE_AND_GET_URL_TOOL.name]: async (request) => {
-    const {bucketName, key, path, expiresIn} = request.params.arguments as {
+    const { bucketName, key, path, expiresIn } = request.params.arguments as {
       bucketName: string;
       key: string;
       path: string;
@@ -289,14 +288,7 @@ export const OBJECT_TOOLS_HANDLER: ToolHandlers = {
 
     await putObjectFromFS(bucketName, key, path);
 
-    const S3 = createS3Client();
-    let url = '';
-
-    if (await isBucketPublic(S3, bucketName)) {
-      url = `https://${bucketName}.fly.storage.tigris.dev/${key}`;
-    } else {
-      url = await getSignedUrlForObject(bucketName, key, expiresIn);
-    }
+    const url = await getSignedUrlForObject(bucketName, key, expiresIn);
 
     return {
       content: [
@@ -400,7 +392,7 @@ const getSignedUrlForObject = async (
     new GetObjectCommand({
       Bucket: bucketName,
       Key: fileName,
-      ResponseContentDisposition: "inline",
+      ResponseContentDisposition: 'inline',
     }),
     {
       expiresIn,

--- a/src/utils/create-s3-client.ts
+++ b/src/utils/create-s3-client.ts
@@ -8,6 +8,7 @@ export function createS3Client() {
     AWS_ACCESS_KEY_ID = '',
     AWS_SECRET_ACCESS_KEY = '',
     AWS_ENDPOINT_URL_S3,
+    AWS_REGION = 'auto',
   } = process.env;
 
   return new S3Client({
@@ -18,7 +19,7 @@ export function createS3Client() {
             accessKeyId: AWS_ACCESS_KEY_ID,
             secretAccessKey: AWS_SECRET_ACCESS_KEY,
           },
-    region: 'auto',
+    region: AWS_REGION,
     endpoint: AWS_ENDPOINT_URL_S3,
   });
 }

--- a/src/utils/get-bucket-acls.ts
+++ b/src/utils/get-bucket-acls.ts
@@ -1,0 +1,11 @@
+import { S3Client } from "@aws-sdk/client-s3";
+import { GetBucketAclCommand } from "@aws-sdk/client-s3";
+
+export const getBucketAcl = async (S3: S3Client, bucketName: string) => {
+  return S3.send(new GetBucketAclCommand({ Bucket: bucketName }));
+};
+
+export const isBucketPublic = async (S3: S3Client, bucketName: string) => {
+  const acl = await getBucketAcl(S3, bucketName);
+  return acl.Grants?.some((grant: any) => grant.Grantee?.Type === 'Group' && grant.Grantee?.URI === 'http://acs.amazonaws.com/groups/global/AllUsers');
+};

--- a/src/utils/get-bucket-acls.ts
+++ b/src/utils/get-bucket-acls.ts
@@ -1,5 +1,5 @@
-import { S3Client } from "@aws-sdk/client-s3";
-import { GetBucketAclCommand } from "@aws-sdk/client-s3";
+import { S3Client } from '@aws-sdk/client-s3';
+import { GetBucketAclCommand } from '@aws-sdk/client-s3';
 
 export const getBucketAcl = async (S3: S3Client, bucketName: string) => {
   return S3.send(new GetBucketAclCommand({ Bucket: bucketName }));
@@ -7,5 +7,9 @@ export const getBucketAcl = async (S3: S3Client, bucketName: string) => {
 
 export const isBucketPublic = async (S3: S3Client, bucketName: string) => {
   const acl = await getBucketAcl(S3, bucketName);
-  return acl.Grants?.some((grant: any) => grant.Grantee?.Type === 'Group' && grant.Grantee?.URI === 'http://acs.amazonaws.com/groups/global/AllUsers');
+  return acl.Grants?.some(
+    grant =>
+      grant.Grantee?.Type === 'Group' &&
+      grant.Grantee?.URI === 'http://acs.amazonaws.com/groups/global/AllUsers',
+  );
 };


### PR DESCRIPTION
This is a composite of two changes:

* src/tools/buckets.ts: attach isPublic metadata to listed buckets
* src/tools/objects.ts: implement upload_file_and_get_url tool

This changes the list_buckets call to include an `isPublic` value that is set to true if the bucket is public as defined by the ACL grants including the URI http://acs.amazonaws.com/groups/global/AllUsers.

The `upload_file_and_get_url` tool uses this `isPublic` value to determine if it should generate a presigned URL or not. If the bucket is private, then it will generate a presigned URL, if not then it generates a public one.

This enables the workflow of uploading a file to a bucket and then getting a URL so you can share it with your friends.