### PR TITLE
feat: Update mcp server to use `storageapi.dev` domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🦁 Tigris MCP Server
 
 > [!IMPORTANT]
-> Tigris has a hosted MCP server with OAuth support. Read more about it on [mcp.storage.dev](https://mcp.storage.dev).
+> Tigris has a hosted MCP server with OAuth support. Read more about it on [mcp.storageapi.dev](https://mcp.storageapi.dev).
 
 Tigris is a high-performance, S3-compatible object storage system designed for multi-cloud and AI workloads. We move your data all around the world based on where it's needed so that downloads are fast and the data is close to your users. You can store anything you want on Tigris (AI models, training data, database backups, request logs, social media uploads, or anything else) with no egress fees.
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -170,7 +170,7 @@ export async function init(
         type: 'input',
         name: 'awsEndpointUrl',
         message: 'Enter Tigris Endpoint:',
-        default: 'https://t3.storage.dev',
+        default: 'https://t3.storageapi.dev',
       },
     ]);
     env.AWS_ENDPOINT_URL_S3 = awsEndpointUrl;
@@ -225,14 +225,14 @@ export async function init(
     config = {
       tigris: {
         type: 'http',
-        url: 'https://mcp.storage.dev/mcp',
+        url: 'https://mcp.storageapi.dev/mcp',
       },
     };
   }
 
   if (selectedApplication === 'Claude for Desktop' && transport === 'http') {
     console.log(
-      'You can add the Tigris MCP Server to Claude for Desktop by using Connectors, please refer to the following link: https://mcp.storage.dev',
+      'You can add the Tigris MCP Server to Claude for Desktop by using Connectors, please refer to the following link: https://mcp.storageapi.dev',
     );
     return;
   }


### PR DESCRIPTION
relates to TIG-7441

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> String-only changes to default URLs and docs; main risk is misconfiguration if any endpoint is incorrect or not yet fully rolled out.
> 
> **Overview**
> **Switches the hosted MCP server domain from `storage.dev` to `storageapi.dev`.**
> 
> Updates documentation and `init` defaults to point users and generated configs at the new endpoints (`https://mcp.storageapi.dev/mcp` and default S3 endpoint `https://t3.storageapi.dev`), including the Claude Desktop connector guidance link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6e74aecfe366522b9c7d66786954382c10964e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->